### PR TITLE
Fix font-styling issue and potentially accepting custom styling class

### DIFF
--- a/dist/leaflet.icon-material.js
+++ b/dist/leaflet.icon-material.js
@@ -44,7 +44,7 @@
             svg.setAttribute('width', options.iconSize[0]);
             svg.setAttribute('height', options.iconSize[1]);
             svg.setAttribute('viewBox', '0 0 31 42');
-            svg.setAttribute('class', 'l-icon-material');
+            svg.setAttribute('class', options.className);
             svg.setAttribute('style', 'margin-left:-' + parseInt(options.iconSize[0]/2) + 'px; margin-top:-' + options.iconSize[1] + 'px')
             svg.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
             
@@ -62,6 +62,7 @@
             icon.setAttribute('x', '7');
             icon.setAttribute('y', '23');
             icon.setAttribute('class', 'material-icons');
+            icon.setAttribute('style', 'font-size: 17px');
             icon.setAttribute('fill', options.iconColor);
             icon.setAttribute('font-family', 'Material Icons');
 

--- a/dist/leaflet.icon-material.js
+++ b/dist/leaflet.icon-material.js
@@ -11,6 +11,8 @@
 
 /*global L*/
 
+import './leaflet.icon-material.css';
+
 (function (window, document, undefined) {
     "use strict";
 
@@ -43,8 +45,9 @@
 
             svg.setAttribute('width', options.iconSize[0]);
             svg.setAttribute('height', options.iconSize[1]);
-            svg.setAttribute('viewBox', '0 0 31 42');
             svg.setAttribute('class', options.className);
+            svg.setAttribute('viewBox', '0 0 31 42');
+            svg.setAttribute('class', 'l-icon-material');
             svg.setAttribute('style', 'margin-left:-' + parseInt(options.iconSize[0]/2) + 'px; margin-top:-' + options.iconSize[1] + 'px')
             svg.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
             
@@ -62,7 +65,6 @@
             icon.setAttribute('x', '7');
             icon.setAttribute('y', '23');
             icon.setAttribute('class', 'material-icons');
-            icon.setAttribute('style', 'font-size: 17px');
             icon.setAttribute('fill', options.iconColor);
             icon.setAttribute('font-family', 'Material Icons');
 


### PR DESCRIPTION
Hi, thank you so much for creating this library!! I love how easy to implement and visually pleasing the material-ui icon markers looks on the map.

I confirmed on 3 different environments that the icon font is too big that it gets tipped over the marker. I noticed that this might be because of the svg not having read access to the styling classes.

Before
<img src="https://i.imgur.com/fBHYvSD.png" height="200" />
After
<img src="https://imgur.com/64EAvfA.png" height="200" />

I would like to propose an idea of having a custom class to be accepted as an option like how it's currently accepting markerColor, outlineColor, outlineWidth, etc as an option. In my case I wanted to add custom css animations to the marker of it blinking and just pass it as a className.

Feel free to correct me if I am catching incorrectly or mistaken something.
Thanks!